### PR TITLE
Get library building and testing in Windows:

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "build": "rm -rf ./dist/ && npm run typings && npm run lint && npm run tscompile && npm run babel",
     "pretest": "npm run build",
     "prepublish": "npm test",
-    "test": "./node_modules/mocha/bin/mocha --require babel-polyfill --require babel-core/register dist/es6/test/spec/**/*.js",
-    "tscompile": "./node_modules/typescript/bin/tsc -d -p ./",
+    "test": "bash -c \"./node_modules/mocha/bin/mocha --require babel-polyfill --require babel-core/register dist/es6/test/spec/**/*.js\"",
+    "tscompile": "bash -c \"./node_modules/typescript/bin/tsc -d -p ./\"",
     "typings": "./node_modules/.bin/typings install",
     "docs": "rm -rf ./docs/ && ./node_modules/typedoc/bin/typedoc --mode file --theme default --experimentalAsyncFunctions --target es6 --out ./docs/ ./lib/ && touch ./docs/.nojekyll",
     "gh-pages": "npm run docs && ./node_modules/gh-pages/bin/gh-pages --dotfiles true -d ./docs/",
-    "lint": "./node_modules/tslint/bin/tslint -c ./tslint.json ./{test,lib}/**/*.ts && echo '> \\033[0;32mlinter passed!\\033[0m'"
+    "lint": "bash -c \"./node_modules/tslint/bin/tslint -c ./tslint.json ./{test,lib}/**/*.ts && echo '> \\033[0;32mlinter passed!\\033[0m'\""
   },
   "engines": {
     "node": ">=4.3.0"

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "./dist/node4/lib/tyranid-gracl.js",
   "typings": "./dist/es6/lib/tyranid-gracl.d.ts",
   "scripts": {
-    "babel": "./node_modules/.bin/babel ./dist/es6 --out-dir ./dist/node4",
-    "build": "rm -rf ./dist/ && npm run typings && npm run lint && npm run tscompile && npm run babel",
+    "babel": "bash -c \"./node_modules/.bin/babel ./dist/es6 --out-dir ./dist/node4\"",
+    "build": "bash -c \"rm -rf ./dist/\" && npm run typings && npm run lint && npm run tscompile && npm run babel",
     "pretest": "npm run build",
     "prepublish": "npm test",
     "test": "bash -c \"./node_modules/mocha/bin/mocha --require babel-polyfill --require babel-core/register dist/es6/test/spec/**/*.js\"",
     "tscompile": "bash -c \"./node_modules/typescript/bin/tsc -d -p ./\"",
     "typings": "./node_modules/.bin/typings install",
-    "docs": "rm -rf ./docs/ && ./node_modules/typedoc/bin/typedoc --mode file --theme default --experimentalAsyncFunctions --target es6 --out ./docs/ ./lib/ && touch ./docs/.nojekyll",
+    "docs": "bash -c \"rm -rf ./docs/ && ./node_modules/typedoc/bin/typedoc --mode file --theme default --experimentalAsyncFunctions --target es6 --out ./docs/ ./lib/ && touch ./docs/.nojekyll\"",
     "gh-pages": "npm run docs && ./node_modules/gh-pages/bin/gh-pages --dotfiles true -d ./docs/",
     "lint": "bash -c \"./node_modules/tslint/bin/tslint -c ./tslint.json ./{test,lib}/**/*.ts && echo '> \\033[0;32mlinter passed!\\033[0m'\""
   },

--- a/test/spec/index.ts
+++ b/test/spec/index.ts
@@ -2,6 +2,7 @@
 /// <reference path='../test-typings.d.ts'/>
 import Tyr from 'tyranid';
 import * as mongodb from 'mongodb';
+import * as path from 'path';
 import * as _ from 'lodash';
 import * as tyranidGracl from '../../lib/tyranid-gracl';
 import { expect } from 'chai';
@@ -29,9 +30,8 @@ const permissionTypes = [
   ]},
 ];
 
-
 const permissionKey = 'graclResourcePermissionIds',
-      root = __dirname.replace(/test\/spec/, ''),
+      root = __dirname.replace(`${path.sep}test${path.sep}spec`, ''),
       secure = new tyranidGracl.GraclPlugin({
         verbose: VERBOSE_LOGGING,
         permissionsProperty: permissionKey,
@@ -67,7 +67,7 @@ describe('tyranid-gracl', () => {
     Tyr.config({
       db: db,
       validate: [
-        { dir: root + '/test/models',
+        { dir: root + `${path.sep}test${path.sep}models`,
           fileMatch: '[a-z].js' }
       ],
       secure: secure,


### PR DESCRIPTION
- Use platform-agnostic path separators
- Workaround buggy Windows npm shell issues by wrapping scripts in bash
  - See https://github.com/npm/npm/issues/9420

I think these changes work on Mac as well, but sadly I have no way to verify.